### PR TITLE
talr-vpcdns fix

### DIFF
--- a/sam/functions/talr-vpcdns/handler.py
+++ b/sam/functions/talr-vpcdns/handler.py
@@ -77,7 +77,6 @@ def handler(event, context):
             return "Nothing to do"
 
     # Look up the account info from the known accountId
-    log.debug(accountLaId)
     getAccountId = accountInfo.query(
         IndexName='gsiAccountId',
         KeyConditionExpression=Key('accountId').eq(accountLaId)
@@ -363,8 +362,6 @@ def get_dns_server_ips(cs_credentials, routes_threshold, region):
             dnsStacks.append({'stackId': i['StackId'], 'vpcId': vpcId, 'dnsA': dnsA, 'dnsB': dnsB})
         else:
             continue
-
-        print(dnsStacks)
 
     noVpcs = 0
     for i in dnsStacks:

--- a/sam/functions/talr-vpcdns/handler.py
+++ b/sam/functions/talr-vpcdns/handler.py
@@ -43,8 +43,8 @@ def handler(event, context):
     # to a dictionary first
     cfnIncomingMessage = {}
     for line in incomingMessage:
-        key = line.replace('\n', '').partition("=")[0]
-        value = line.replace('\n', '').partition("=")[2].lstrip("'").rstrip("'")
+        key = line.partition("=")[0]
+        value = line.partition("=")[2].lstrip("'").rstrip("'")
         cfnIncomingMessage[key] = value
     print("cfnIncomingMessage:", cfnIncomingMessage)
 


### PR DESCRIPTION
The 'Message' payload included with the SNS message sent to detect core stack completion has changed. This caused the function to fail to populate linked account information to detect both core stack completion and the linked account VPC.

Patched the if-statement logic to check data differently before proceeding that conforms to the new payload.